### PR TITLE
counter state type = AppState { count :: Int }

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 .psci
 .psci_modules
+.psc-ide-port
 .pulp-cache
 npm-debug.log
 node_modules/


### PR DESCRIPTION
I modified the counter example by changing the application state to model Phil's purescript-react example in Chapter8 of  "PureScript by Example". He represents state as a `newtype` constructor `AppState { a :: TypeA, b :: TypeB }`.  

So I changed the `State` type from `String` to a `AppState { count :: Int } new type`  I believe this modification is more idiomatic PureScript and therefore will more helpful to anyone looking for an example on how to manage state in their purescript-react app