### PR TITLE
Update webpack dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
   "devDependencies": {
     "pscid": "^2.0.2",
     "purescript": "^0.12.0",
-    "purs-loader": "^3.0.0",
-    "webpack": "^4.0.0",
-    "webpack-cli": "^2.0.10",
+    "purs-loader": "^3.2.0",
+    "webpack": "^4.2.0",
+    "webpack-cli": "^3.1.1",
     "webpack-dev-server": "^3.0.0"
   }
 }


### PR DESCRIPTION
Following the readme instructions, I couldn't get `npm run webpack-dev-server` to run as it gave an error "TypeError: Cannot read property 'properties' of undefined". I believe this is the same as https://github.com/webpack/webpack/issues/8082 so I updated some dependencies and it now runs. I'm not certain that this is the correct fix, but at least other people can apply this change to get the project running. (For reference I'm using `npm 5.6.0` and `bower 1.8.4`)